### PR TITLE
Connectors try to update a lot more twins than it's required - EI-750

### DIFF
--- a/src/messages.rs
+++ b/src/messages.rs
@@ -1,7 +1,7 @@
 use actix::Message;
 use std::time::SystemTime;
 
-use iotics_grpc_client::common::{Channel, Property};
+use iotics_grpc_client::common::Channel;
 use iotics_grpc_client::twin::{FeedApiClient, TwinApiClient};
 
 use crate::connector::ConnectorData;
@@ -25,12 +25,6 @@ pub struct TwinData {
     pub model_did: String,
     pub data: ConnectorData,
     pub expire_time: SystemTime,
-}
-
-#[derive(Debug, Message, Clone)]
-#[rtype(result = "()")]
-pub struct TwinProperties {
-    pub properties: Vec<Property>,
 }
 
 #[derive(Debug, Message, Clone)]

--- a/src/model_actor.rs
+++ b/src/model_actor.rs
@@ -25,7 +25,7 @@ use crate::constants::{
 };
 use crate::messages::{
     ChannelsCreatedMessage, Cleanup, GetData, HeartbeatData, ShareConcurrencyReduction,
-    TwinConcurrencyReduction, TwinData, TwinProperties,
+    TwinConcurrencyReduction, TwinData,
 };
 use crate::model::Model;
 use crate::twin::Twin;
@@ -376,12 +376,8 @@ impl Handler<TwinData> for ModelActor {
         }
 
         self.concurrent_shares += message.data.feeds.len();
-        // Share/update twin data
-        twin_actor.addr.do_send(message.clone());
-        // Share/update twin properties
-        twin_actor.addr.do_send(TwinProperties {
-            properties: message.data.properties,
-        });
+        // Share/update twin data & properties
+        twin_actor.addr.do_send(message);
     }
 }
 


### PR DESCRIPTION
Update twin calls are happening even when there are 0 properties to update (properties array is empty).
This is creating a lot of unnecessary stress on the host.

This can be easily fixed by calling update twins only when the properties array is not empty.